### PR TITLE
Fix podspec source

### DIFF
--- a/Google-diff-Match-Patch.podspec
+++ b/Google-diff-Match-Patch.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'Apache License, Version 2.0', :file => 'COPYING' }
   s.authors      = { 'Neil Fraser' => 'fraser@google.com', 'Jan Weiß' => 'jan@geheimwerk.de' }
   
-  Pod::Specs.source       = { :git => "https://github.com/JanX2/google-diff-match-patch-Objective-C.git", :tag => "v1.0.6" }
+  s.source       = { :git => "https://github.com/JanX2/google-diff-match-patch-Objective-C.git", :tag => s.version }
   
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'


### PR DESCRIPTION
Hello @JanX2 , the latest master builds for Xcode 9 (and earlier Xcode versions), however install with Cocoapods isn't getting the latest version because of a podspec issue and that prevents Xcode 9 from building (https://github.com/JanX2/google-diff-match-patch-Objective-C/issues/4). This PR fixes the podspec issue. Would be very helpful for anyone using this library with Cocoapods & Xcode 9!